### PR TITLE
Add detected object names to spoken warning

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,88 @@
   let lastWarnAt = 0;
   let model = null;
   const targetSet = new Set(['person', 'cat', 'dog']);
+  const labelMap = {
+    person: '人物',
+    bicycle: '自転車',
+    car: '車',
+    motorcycle: 'オートバイ',
+    airplane: '飛行機',
+    bus: 'バス',
+    train: '電車',
+    truck: 'トラック',
+    boat: 'ボート',
+    'traffic light': '信号機',
+    'fire hydrant': '消火栓',
+    'stop sign': '一時停止標識',
+    'parking meter': 'パーキングメーター',
+    bench: 'ベンチ',
+    bird: '鳥',
+    cat: '猫',
+    dog: '犬',
+    horse: '馬',
+    sheep: '羊',
+    cow: '牛',
+    elephant: '象',
+    bear: '熊',
+    zebra: 'シマウマ',
+    giraffe: 'キリン',
+    backpack: 'バックパック',
+    umbrella: '傘',
+    handbag: 'ハンドバッグ',
+    tie: 'ネクタイ',
+    suitcase: 'スーツケース',
+    frisbee: 'フリスビー',
+    skis: 'スキー板',
+    snowboard: 'スノーボード',
+    'sports ball': 'ボール',
+    kite: '凧',
+    'baseball bat': '野球バット',
+    'baseball glove': '野球グローブ',
+    skateboard: 'スケートボード',
+    surfboard: 'サーフボード',
+    'tennis racket': 'テニスラケット',
+    bottle: 'ボトル',
+    'wine glass': 'ワイングラス',
+    cup: 'コップ',
+    fork: 'フォーク',
+    knife: 'ナイフ',
+    spoon: 'スプーン',
+    bowl: 'ボウル',
+    banana: 'バナナ',
+    apple: 'リンゴ',
+    sandwich: 'サンドイッチ',
+    orange: 'オレンジ',
+    broccoli: 'ブロッコリー',
+    carrot: 'ニンジン',
+    'hot dog': 'ホットドッグ',
+    pizza: 'ピザ',
+    donut: 'ドーナツ',
+    cake: 'ケーキ',
+    chair: '椅子',
+    couch: 'ソファ',
+    'potted plant': '観葉植物',
+    bed: 'ベッド',
+    'dining table': '食卓',
+    toilet: 'トイレ',
+    tv: 'テレビ',
+    laptop: 'ノートパソコン',
+    mouse: 'マウス',
+    remote: 'リモコン',
+    keyboard: 'キーボード',
+    'cell phone': '携帯電話',
+    microwave: '電子レンジ',
+    oven: 'オーブン',
+    toaster: 'トースター',
+    sink: '流し台',
+    refrigerator: '冷蔵庫',
+    book: '本',
+    clock: '時計',
+    vase: '花瓶',
+    scissors: 'はさみ',
+    'teddy bear': 'テディベア',
+    'hair drier': 'ドライヤー',
+    toothbrush: '歯ブラシ',
+  };
 
   const beep = () => {
     try {
@@ -129,7 +211,21 @@
 
       draw(detections);
       if (filtered.length > 0) {
-        speak(warningTextInput.value || '警告：ここは立入禁止です。直ちに立ち去ってください。');
+        const msg = (() => {
+          const base = (warningTextInput.value || '警告：ここは立入禁止です。直ちに立ち去ってください。').trim();
+          const counts = new Map();
+          filtered.forEach((d) => {
+            const label = labelMap[d.class] || d.class;
+            counts.set(label, (counts.get(label) || 0) + 1);
+          });
+          if (counts.size === 0) return base;
+          const parts = Array.from(counts.entries()).map(([label, count]) => (count > 1 ? `${label} ${count}件` : label));
+          const detail = parts.join('、');
+          const cleanedBase = base.replace(/[。．.!?！？\s]+$/u, '');
+          const basePart = cleanedBase ? `${cleanedBase}。` : '';
+          return `${basePart}${detail}を検知しました。`;
+        })();
+        speak(msg);
         statusEl.textContent = `検知: ${filtered.length}件 / しきい値 ${Math.round(Number(th.value) * 100)}%`;
       } else {
         statusEl.textContent = `検知なし / しきい値 ${Math.round(Number(th.value) * 100)}%`;


### PR DESCRIPTION
## Summary
- expand the label map to cover every COCO-SSD class with Japanese speech-friendly names
- refine the spoken warning template so detected objects form a natural sentence

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ca36acfc34832988c55d9ea0facc4f