### PR TITLE
Integrate webcam heart-rate estimation with speech

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,13 @@
 (() => {
+  const SAMPLE_W = 160;
+  const SAMPLE_H = 120;
+  const PANEL_INTERVAL = 300;
+  const HR_SAMPLE_MS = 50;
+  const HR_WINDOW_SEC = 12;
+  const HR_MIN_HZ = 0.8;
+  const HR_MAX_HZ = 3.0;
+  const HR_STEP_HZ = 0.02;
+
   const $ = (sel) => document.querySelector(sel);
   const video = $('#video');
   const canvas = $('#canvas');
@@ -17,9 +26,27 @@
   const minVal = $('#minVal');
   const warningTextInput = $('#warningText');
 
+  const panelText = $('#panel-text');
+  const ambientEl = $('#ambient');
+  const contrastEl = $('#contrast');
+  const colorEl = $('#color');
+  const phaseEl = $('#phase');
+  const bpmEl = $('#bpm');
+  const bpmPhraseEl = $('#bpmPhrase');
+
+  const sampleCanvas = $('#sample');
+  const sampleCtx = sampleCanvas.getContext('2d');
+
   let running = false;
+  let sampleTimer = null;
+  let hrTimer = null;
   let lastWarnAt = 0;
   let model = null;
+  let lastBrightness = null;
+  let lastHeartSpeakAt = 0;
+  let heartSignal = [];
+  let heartTime = [];
+
   const targetSet = new Set(['person', 'cat', 'dog']);
   const labelMap = {
     person: '人物',
@@ -27,23 +54,126 @@
     dog: '犬',
   };
 
+  const toPercent = (value) => Math.min(100, Math.max(0, value)).toFixed(1);
+
+  const resetMetrics = () => {
+    panelText.textContent = 'H ---%\nE ----\nS ----\nEV ---';
+    ambientEl.textContent = '--.- % / min -- / max --';
+    contrastEl.textContent = 'std --.- / motion --.-';
+    colorEl.textContent = 'R --.- / G --.- / B --.-';
+    phaseEl.textContent = 'IDLE';
+    bpmEl.textContent = '-- bpm';
+    bpmPhraseEl.textContent = '心拍計測が開始されると、状態に合わせたボイスが流れます。';
+  };
+
+  const computeMetrics = () => {
+    if (!video.videoWidth || !video.videoHeight) return null;
+    sampleCtx.drawImage(video, 0, 0, SAMPLE_W, SAMPLE_H);
+    const { data } = sampleCtx.getImageData(0, 0, SAMPLE_W, SAMPLE_H);
+    const pixelCount = SAMPLE_W * SAMPLE_H;
+
+    let sum = 0;
+    let sumSq = 0;
+    let min = 255;
+    let max = 0;
+    let rSum = 0, gSum = 0, bSum = 0;
+    let motionAccum = 0;
+
+    const currentBrightness = new Float32Array(pixelCount);
+
+    for (let i = 0, p = 0; i < data.length; i += 4, p++) {
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      const brightness = (r + g + b) / 3;
+
+      currentBrightness[p] = brightness;
+      sum += brightness;
+      sumSq += brightness * brightness;
+      if (brightness < min) min = brightness;
+      if (brightness > max) max = brightness;
+
+      rSum += r;
+      gSum += g;
+      bSum += b;
+
+      if (lastBrightness && lastBrightness[p] !== undefined) {
+        motionAccum += Math.abs(brightness - lastBrightness[p]);
+      }
+    }
+
+    const mean = sum / pixelCount;
+    const variance = sumSq / pixelCount - mean * mean;
+    const stddev = Math.sqrt(Math.max(variance, 0));
+    const motionScore = lastBrightness ? (motionAccum / (pixelCount * 255)) * 100 : 0;
+    lastBrightness = currentBrightness;
+
+    const rMean = rSum / pixelCount;
+    const gMean = gSum / pixelCount;
+    const bMean = bSum / pixelCount;
+
+    return { mean, min, max, stddev, motionScore, rMean, gMean, bMean };
+  };
+
+  const deriveCodes = (metrics) => {
+    const { mean, stddev, motionScore, rMean, gMean, bMean } = metrics;
+    const ambientPercent = (mean / 255) * 100;
+    const contrastCode = stddev < 15 ? 'L' : stddev < 40 ? 'M' : 'H';
+    const motionCode = motionScore < 1 ? 'S' : motionScore < 5 ? 'M' : 'A';
+
+    let bias = 'N';
+    const rg = rMean - gMean;
+    const gb = gMean - bMean;
+    const rb = rMean - bMean;
+    const threshold = 5;
+    if (rg > threshold && rb > threshold) bias = 'R';
+    else if (gb > threshold && -rg > threshold) bias = 'G';
+    else if (-rb > threshold && -gb > threshold) bias = 'B';
+
+    const envCode = ambientPercent < 20 ? 'DK' : ambientPercent > 80 ? 'BR' : 'NM';
+    const ev = `${envCode}/${bias}`;
+
+    const panel = [
+      `H ${toPercent(ambientPercent)}%`,
+      `E ${SAMPLE_W}x${SAMPLE_H} M${motionCode} C${contrastCode}`,
+      `S ${running ? 'LIVE' : 'IDLE'}`,
+      `EV ${ev}`
+    ].join('\n');
+
+    return { panel, ambientPercent, ev };
+  };
+
+  const updateMetrics = () => {
+    if (!running) return;
+    const metrics = computeMetrics();
+    if (!metrics) return;
+    const { mean, min, max, stddev, motionScore, rMean, gMean, bMean } = metrics;
+    const { panel, ambientPercent, ev } = deriveCodes(metrics);
+
+    panelText.textContent = panel;
+    ambientEl.textContent = `${toPercent(ambientPercent)} % / min ${min.toFixed(0)} / max ${max.toFixed(0)}`;
+    contrastEl.textContent = `std ${stddev.toFixed(1)} / motion ${motionScore.toFixed(1)}`;
+    colorEl.textContent = `R ${rMean.toFixed(1)} / G ${gMean.toFixed(1)} / B ${bMean.toFixed(1)}`;
+    phaseEl.textContent = `${running ? 'LIVE' : 'IDLE'} · EV ${ev}`;
+  };
+
   const beep = () => {
     try {
       const Ctx = window.AudioContext || window.webkitAudioContext;
       if (!Ctx) return;
-      const ctx = new Ctx();
-      const o = ctx.createOscillator();
-      const g = ctx.createGain();
+      const audioCtx = new Ctx();
+      const o = audioCtx.createOscillator();
+      const g = audioCtx.createGain();
       o.type = 'square';
       o.frequency.value = 1800;
       o.connect(g);
-      g.connect(ctx.destination);
-      g.gain.setValueAtTime(0.0001, ctx.currentTime);
-      g.gain.exponentialRampToValueAtTime(0.2, ctx.currentTime + 0.02);
-      g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.4);
+      g.connect(audioCtx.destination);
+      g.gain.setValueAtTime(0.0001, audioCtx.currentTime);
+      g.gain.exponentialRampToValueAtTime(0.2, audioCtx.currentTime + 0.02);
+      g.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.4);
       o.start();
-      o.stop(ctx.currentTime + 0.42);
-    } catch (_) {}
+      o.stop(audioCtx.currentTime + 0.42);
+    } catch (_) { }
   };
 
   const speak = (text) => {
@@ -57,11 +187,85 @@
         u.rate = 1.0; u.pitch = 1.0; u.volume = 1.0;
         window.speechSynthesis.cancel();
         window.speechSynthesis.speak(u);
-      } else {
+      } else if (voiceModeSel.value === 'beep') {
         beep();
       }
       lastWarnAt = now;
-    } catch (e) {}
+    } catch (e) { }
+  };
+
+  const collectHeartSample = () => {
+    if (!running || !video.videoWidth || !video.videoHeight) return;
+    sampleCtx.drawImage(video, 0, 0, SAMPLE_W, SAMPLE_H);
+    const cx = Math.floor(SAMPLE_W * 0.25);
+    const cy = Math.floor(SAMPLE_H * 0.25);
+    const w = Math.floor(SAMPLE_W * 0.5);
+    const h = Math.floor(SAMPLE_H * 0.5);
+    const { data } = sampleCtx.getImageData(cx, cy, w, h);
+    let gSum = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      gSum += data[i + 1];
+    }
+    const meanG = gSum / (data.length / 4);
+    const now = performance.now();
+    heartSignal.push(meanG);
+    heartTime.push(now);
+
+    // keep window
+    const cutoff = now - HR_WINDOW_SEC * 1000;
+    while (heartTime.length > 0 && heartTime[0] < cutoff) {
+      heartTime.shift();
+      heartSignal.shift();
+    }
+  };
+
+  const estimateHeartRate = () => {
+    if (heartSignal.length < 30) return null;
+    const n = heartSignal.length;
+    const durationSec = (heartTime[n - 1] - heartTime[0]) / 1000;
+    if (durationSec < 4) return null;
+    const mean = heartSignal.reduce((a, b) => a + b, 0) / n;
+    const values = heartSignal.map((v) => v - mean);
+    const dt = durationSec / (n - 1);
+    let best = { f: 0, power: 0 };
+    for (let f = HR_MIN_HZ; f <= HR_MAX_HZ; f += HR_STEP_HZ) {
+      let re = 0, im = 0;
+      const omega = -2 * Math.PI * f * dt;
+      for (let i = 0; i < n; i++) {
+        const phi = omega * i;
+        re += values[i] * Math.cos(phi);
+        im += values[i] * Math.sin(phi);
+      }
+      const power = (re * re + im * im) / n;
+      if (power > best.power) {
+        best = { f, power };
+      }
+    }
+    if (best.f === 0) return null;
+    return { bpm: Math.round(best.f * 60), strength: best.power };
+  };
+
+  const heartPhrase = (bpm) => {
+    if (!bpm || Number.isNaN(bpm)) return '計測中...';
+    if (bpm < 60) return 'リラックス状態です。穏やかな呼吸を維持しましょう。';
+    if (bpm < 90) return '安定しています。このままキープ。';
+    if (bpm < 110) return '少し高めです。深呼吸で落ち着けます。';
+    return '高心拍を検知。少し休憩してください。';
+  };
+
+  const updateHeartRate = () => {
+    const est = estimateHeartRate();
+    if (!est) return;
+    const { bpm, strength } = est;
+    const phrase = heartPhrase(bpm);
+    bpmEl.textContent = `${bpm} bpm`;
+    bpmPhraseEl.textContent = phrase;
+
+    const now = Date.now();
+    if (strength > 0.1 && now - lastHeartSpeakAt > 8000) {
+      speak(`心拍数 ${bpm}、${phrase}`);
+      lastHeartSpeakAt = now;
+    }
   };
 
   const startCamera = async () => {
@@ -88,7 +292,7 @@
       ctx.globalAlpha = 0.7; ctx.fillRect(x, Math.max(0, y - 20), tw, 20); ctx.globalAlpha = 1;
       ctx.fillStyle = '#fff'; ctx.fillText(tag, x + 4, Math.max(14, y - 6));
     });
-    // inner zone guide
+
     const cw = canvas.width, ch = canvas.height;
     const m = (Number(zone.value) / 100);
     const ix = m * cw, iy = m * ch, iw = cw - ix * 2, ih = ch - iy * 2;
@@ -97,7 +301,6 @@
     ctx.strokeRect(ix, iy, iw, ih);
     ctx.setLineDash([]);
 
-    // timestamp overlay (top-right)
     const d = new Date();
     const fmt2 = (n) => (n < 10 ? '0' + n : '' + n);
     const ts = `${d.getFullYear()}-${fmt2(d.getMonth()+1)}-${fmt2(d.getDate())} ${fmt2(d.getHours())}:${fmt2(d.getMinutes())}:${fmt2(d.getSeconds())}`;
@@ -150,17 +353,15 @@
       } else {
         statusEl.textContent = `検知なし / しきい値 ${Math.round(Number(th.value) * 100)}%`;
       }
-    } catch (e) {}
+    } catch (e) { }
     requestAnimationFrame(loop);
   };
 
-  // UI bindings
   th.addEventListener('input', () => (thVal.textContent = `${Math.round(Number(th.value) * 100)}%`));
   zone.addEventListener('input', () => (zoneVal.textContent = `${Number(zone.value)}`));
   minArea.addEventListener('input', () => (minVal.textContent = `${Number(minArea.value)}`));
   testSpeak.addEventListener('click', () => speak('テスト: 警告ボイスの確認です'));
 
-  // clock (1s interval)
   const fmt = (n) => (n < 10 ? '0' + n : '' + n);
   const tick = () => {
     const d = new Date();
@@ -177,21 +378,45 @@
     });
   });
 
+  const startMetrics = () => {
+    if (sampleTimer) clearInterval(sampleTimer);
+    sampleTimer = setInterval(updateMetrics, PANEL_INTERVAL);
+    if (hrTimer) clearInterval(hrTimer);
+    hrTimer = setInterval(() => {
+      collectHeartSample();
+      updateHeartRate();
+    }, HR_SAMPLE_MS);
+  };
+
+  const stopMetrics = () => {
+    if (sampleTimer) { clearInterval(sampleTimer); sampleTimer = null; }
+    if (hrTimer) { clearInterval(hrTimer); hrTimer = null; }
+    lastBrightness = null;
+    heartSignal = [];
+    heartTime = [];
+    lastHeartSpeakAt = 0;
+    resetMetrics();
+  };
+
   btn.addEventListener('click', async () => {
     if (!running) {
       try {
         statusEl.textContent = 'モデル読込中...';
-        // ローカルのモデルを明示指定
-        model = await cocoSsd.load({ modelUrl: './models/coco-ssd/model.json' });
+        if (!model) {
+          model = await cocoSsd.load({ modelUrl: './models/coco-ssd/model.json' });
+        }
         statusEl.textContent = 'カメラ初期化中...';
         await startCamera();
         running = true;
         btn.textContent = '停止';
         statusEl.textContent = '稼働中';
+        phaseEl.textContent = 'LIVE';
+        startMetrics();
         requestAnimationFrame(loop);
       } catch (e) {
         statusEl.textContent = `エラー: ${e?.message || e}`;
         running = false; btn.textContent = '開始';
+        stopMetrics();
       }
     } else {
       running = false;
@@ -199,6 +424,15 @@
       const tracks = (video.srcObject && video.srcObject.getTracks && video.srcObject.getTracks()) || [];
       tracks.forEach((t) => t.stop());
       video.srcObject = null;
+      stopMetrics();
     }
   });
+
+  window.addEventListener('beforeunload', () => {
+    if (video.srcObject) {
+      video.srcObject.getTracks().forEach((t) => t.stop());
+    }
+  });
+
+  resetMetrics();
 })();

--- a/index.html
+++ b/index.html
@@ -2,134 +2,91 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <title>ウェルカム検知システム</title>
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/coco-ssd"></script>
-  <style>
-    video, canvas { max-width: 100%; display: block; }
-    #status { margin-top: 8px; font-weight: bold; }
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>COCO-SSD × セカイOCRビジョンパネル</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <button id="toggle">開始</button>
-  <div id="status">待機中</div>
-  <video id="video" autoplay playsinline muted></video>
-  <canvas id="canvas"></canvas>
+  <div class="wrap">
+    <header>
+      <h1>COCO-SSD × セカイOCRビジョンパネル</h1>
+      <p>物体検知のライブ映像に合わせて、OCRフレンドリーな AI ステータス (H / E / S / EV) と環境メトリクスを同時に表示します。</p>
+    </header>
 
-<script>
-(() => {
-  const video = document.getElementById('video');
-  const canvas = document.getElementById('canvas');
-  const ctx = canvas.getContext('2d');
-  const btn = document.getElementById('toggle');
-  const statusEl = document.getElementById('status');
+    <div class="controls">
+      <div class="control-group">
+        <button id="toggle">開始</button>
+        <span class="status" id="status">待機中</span>
+        <span class="clock">Clock: <span id="clock">--:--:--</span></span>
+      </div>
+      <div class="control-group sliders">
+        <label>しきい値 <input id="threshold" type="range" min="0.1" max="1" step="0.01" value="0.5"><span class="mono" id="thVal">50%</span></label>
+        <label>内側ゾーン <input id="zone" type="range" min="0" max="30" step="1" value="10"><span class="mono" id="zoneVal">10</span></label>
+        <label>最小面積(%) <input id="minArea" type="range" min="0" max="20" step="1" value="2"><span class="mono" id="minVal">2</span></label>
+      </div>
+      <div class="control-group">
+        <div class="targets">
+          <span>対象:</span>
+          <label><input type="checkbox" value="person" checked>person</label>
+          <label><input type="checkbox" value="cat" checked>cat</label>
+          <label><input type="checkbox" value="dog" checked>dog</label>
+        </div>
+        <label>音声 <select id="voiceMode"><option value="tts">TTS</option><option value="beep">Beep</option><option value="mute">Mute</option></select></label>
+        <label>クールダウン(s) <input id="cooldown" type="number" min="0" max="30" value="5" class="mono small"></label>
+        <button id="testSpeak" class="ghost">音声テスト</button>
+      </div>
+      <div class="control-group">
+        <label class="wmsg">警告文: <input id="warningText" type="text" value="警告：ここは立入禁止です。直ちに立ち去ってください。"></label>
+      </div>
+    </div>
 
-  let running = false;
-  let model = null;
-  let lastSpeakAt = 0;
-  const cooldownMs = 8000; // 同じ対象で連続発声を防ぐ（ミリ秒）
+    <div class="layout">
+      <div class="stage" aria-label="物体検知プレビュー">
+        <video id="video" autoplay playsinline muted></video>
+        <canvas id="canvas"></canvas>
+        <div class="ocr-panel" aria-live="polite" aria-label="AIステータスパネル">
+          <pre id="panel-text">H ---%
+E ----
+S ----
+EV ---</pre>
+        </div>
+      </div>
+      <div class="info">
+        <div class="card">
+          <h3>AI パネル状態</h3>
+          <div class="value" id="phase">IDLE</div>
+          <p class="desc">H/E/S/EV コードは 300ms ごとに更新。パネルは 150×100px のモノスペース表示。</p>
+        </div>
+        <div class="card">
+          <h3>Heart Rate</h3>
+          <div class="value mono" id="bpm">-- bpm</div>
+          <p class="desc" id="bpmPhrase">ウェブカメラの緑チャネルから心拍を推定し、状態に合わせたセリフを発話します。</p>
+        </div>
+        <div class="metrics">
+          <div class="card">
+            <h3>Ambient Window</h3>
+            <div class="value mono" id="ambient">--.- % / min -- / max --</div>
+            <p class="desc">160×120 サンプルの平均輝度と最小・最大を表示します。</p>
+          </div>
+          <div class="card">
+            <h3>Contrast & Motion</h3>
+            <div class="value mono" id="contrast">std --.- / motion --.-</div>
+            <p class="desc">標準偏差でコントラストを、フレーム差分でモーションスコアを算出します。</p>
+          </div>
+          <div class="card">
+            <h3>Color Bias</h3>
+            <div class="value mono" id="color">R --.- / G --.- / B --.-</div>
+            <p class="desc">チャネル平均の偏りを検知し、環境コード EV に反映します。</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 
-  const targetSet = new Set(['person', 'dog', 'cat']);
-  const labelMap = { person: '人物', dog: '犬', cat: '猫' };
+  <canvas id="sample" class="sr-only" width="160" height="120"></canvas>
 
-  const speak = (text) => {
-    const now = Date.now();
-    if (now - lastSpeakAt < cooldownMs) return;
-    const u = new SpeechSynthesisUtterance(text);
-    u.lang = 'ja-JP';
-    u.rate = 1.0;
-    window.speechSynthesis.cancel();
-    window.speechSynthesis.speak(u);
-    lastSpeakAt = now;
-  };
-
-  const startCamera = async () => {
-    const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' }, audio: false });
-    video.srcObject = stream;
-    await new Promise(r => (video.onloadedmetadata = () => r()));
-    await video.play();
-    canvas.width = video.videoWidth || 640;
-    canvas.height = video.videoHeight || 480;
-  };
-
-  const draw = (preds) => {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-    preds.forEach(p => {
-      const [x, y, w, h] = p.bbox;
-      if (!targetSet.has(p.class)) return;
-      ctx.lineWidth = 2;
-      ctx.strokeStyle = '#ff4136';
-      ctx.strokeRect(x, y, w, h);
-      const tag = `${labelMap[p.class] || p.class} ${(p.score * 100).toFixed(0)}%`;
-      ctx.font = '16px sans-serif';
-      const tw = ctx.measureText(tag).width + 8;
-      ctx.globalAlpha = 0.7; ctx.fillStyle = '#ff4136';
-      ctx.fillRect(x, Math.max(0, y - 20), tw, 20); ctx.globalAlpha = 1;
-      ctx.fillStyle = '#fff'; ctx.fillText(tag, x + 4, Math.max(14, y - 6));
-    });
-  };
-
-  const loop = async () => {
-    if (!running || !model) return;
-    try {
-      const detections = await model.detect(video);
-      draw(detections);
-
-      const filtered = detections.filter(d => targetSet.has(d.class) && d.score >= 0.7);
-      if (filtered.length > 0) {
-        const hasPerson = filtered.some(d => d.class === 'person');
-        const hasDog = filtered.some(d => d.class === 'dog');
-        const hasCat = filtered.some(d => d.class === 'cat');
-
-        let msg = null;
-        // 3種同時
-        if (hasPerson && hasDog && hasCat) msg = '人間とわんちゃんとにゃんこちゃん、いらっしゃい';
-        // 2種組み合わせ
-        else if (hasPerson && hasDog) msg = '人間とわんちゃん、いらっしゃい';
-        else if (hasPerson && hasCat) msg = '人間とにゃんこちゃん、いらっしゃい';
-        else if (hasDog && hasCat) msg = 'わんちゃんとにゃんこちゃん、いらっしゃい';
-        // 単体
-        else if (hasPerson) msg = 'ようこそ、いらっしゃいました';
-        else if (hasDog) msg = 'わんちゃん、いらっしゃい';
-        else if (hasCat) msg = 'にゃんこちゃん、いらっしゃい';
-
-        if (msg) speak(msg);
-        statusEl.textContent = `検知: ${filtered.length}件`;
-      } else {
-        statusEl.textContent = '検知なし';
-      }
-    } catch (e) {
-      statusEl.textContent = `エラー: ${e.message}`;
-    }
-    requestAnimationFrame(loop);
-  };
-
-  btn.addEventListener('click', async () => {
-    if (!running) {
-      try {
-        statusEl.textContent = 'モデル読込中...';
-        model = await cocoSsd.load();
-        statusEl.textContent = 'カメラ起動中...';
-        await startCamera();
-        running = true;
-        btn.textContent = '停止';
-        statusEl.textContent = '稼働中';
-        requestAnimationFrame(loop);
-      } catch (e) {
-        statusEl.textContent = `初期化エラー: ${e.message}`;
-      }
-    } else {
-      running = false;
-      btn.textContent = '開始';
-      statusEl.textContent = '停止中';
-      if (video.srcObject) {
-        video.srcObject.getTracks().forEach(t => t.stop());
-        video.srcObject = null;
-      }
-    }
-  });
-})();
-</script>
+  <script src="assets/tf.min.js"></script>
+  <script src="assets/coco-ssd.min.js"></script>
+  <script src="app.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,11 +1,46 @@
+:root { color-scheme: light dark; }
 * { box-sizing: border-box; }
-body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 0; }
-.wrap { padding: 16px; display: flex; flex-direction: column; gap: 12px; }
-.controls, .filters { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
-.targets label { margin-right: 10px; }
-.wmsg input { width: 100%; max-width: 640px; }
-.status { color: #555; }
-.stage { position: relative; width: 100%; max-width: 960px; }
-video, canvas { width: 100%; height: auto; border-radius: 6px; background: #000; display: block; }
-canvas { position: absolute; left: 0; top: 0; pointer-events: none; }
+body { margin: 0; font-family: 'IBM Plex Sans', 'Noto Sans JP', system-ui, -apple-system, sans-serif; background: #0b0c0f; color: #e5e5e5; }
 
+.wrap { max-width: 1100px; margin: 0 auto; padding: 20px 16px 48px; display: flex; flex-direction: column; gap: 16px; }
+header h1 { margin: 0; font-size: 1.5rem; letter-spacing: 0.02em; }
+header p { margin: 6px 0 0; color: #cfd5df; line-height: 1.6; }
+
+.controls { display: flex; flex-direction: column; gap: 8px; background: #10131a; border: 1px solid #1c2433; border-radius: 10px; padding: 12px; box-shadow: 0 10px 30px rgba(0,0,0,0.35); }
+.control-group { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+.control-group label { display: flex; align-items: center; gap: 8px; font-size: 0.95rem; color: #d8dee9; }
+.control-group input[type="range"] { accent-color: #55a6ff; }
+.control-group input[type="text"], .control-group input[type="number"] { padding: 8px 10px; border-radius: 6px; border: 1px solid #1f2a3a; background: #0f121a; color: #eaeef5; }
+.control-group select { padding: 8px 10px; border-radius: 6px; border: 1px solid #1f2a3a; background: #0f121a; color: #eaeef5; }
+.control-group .small { width: 72px; }
+.control-group .wmsg { flex: 1 1 360px; }
+
+button { padding: 10px 16px; font-size: 1rem; background: linear-gradient(135deg, #2f6bff, #3f8cff); color: #fff; border: none; border-radius: 10px; cursor: pointer; box-shadow: 0 8px 16px rgba(47,107,255,0.35); transition: transform 0.08s ease, box-shadow 0.08s ease; }
+button:hover { transform: translateY(-1px); box-shadow: 0 12px 24px rgba(47,107,255,0.4); }
+button:active { transform: translateY(0); }
+button.ghost { background: #1c2433; box-shadow: none; }
+.status { font-weight: 700; letter-spacing: 0.04em; color: #b5cdfa; }
+.clock { color: #8ea6c9; font-family: 'Roboto Mono', monospace; }
+.targets { display: flex; gap: 10px; align-items: center; }
+.targets label { font-weight: 600; }
+.mono { font-family: 'Roboto Mono', 'SFMono-Regular', Consolas, monospace; }
+
+.layout { display: grid; grid-template-columns: 2fr 1fr; gap: 14px; align-items: start; }
+@media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
+
+.stage { position: relative; width: 100%; border-radius: 14px; overflow: hidden; background: radial-gradient(circle at 20% 20%, #1b2738, #0b0c0f); border: 1px solid #182032; box-shadow: 0 16px 40px rgba(0,0,0,0.45); }
+video, canvas { width: 100%; height: auto; display: block; }
+video { filter: brightness(1.05); }
+canvas { position: absolute; inset: 0; pointer-events: none; }
+
+.ocr-panel { position: absolute; left: 14px; top: 14px; width: 150px; height: 100px; background: #000; color: #f2f2f2; padding: 8px; border-radius: 8px; border: 1px solid #1e1e1e; box-shadow: 0 12px 24px rgba(0,0,0,0.5); }
+.ocr-panel pre { margin: 0; font: 700 13px/1.4 "Roboto Mono", "SFMono-Regular", Consolas, monospace; letter-spacing: 0.04em; }
+
+.info { display: flex; flex-direction: column; gap: 12px; }
+.metrics { display: grid; grid-template-columns: 1fr; gap: 10px; }
+.card { background: #0f131c; border: 1px solid #1c2433; border-radius: 12px; padding: 12px; box-shadow: 0 12px 28px rgba(0,0,0,0.35); }
+.card h3 { margin: 0 0 8px; font-size: 0.95rem; letter-spacing: 0.05em; color: #c8e1ff; }
+.card .value { font-size: 1.05rem; font-weight: 700; letter-spacing: 0.04em; color: #f0f0f0; }
+.card .desc { margin-top: 6px; font-size: 0.9rem; color: #b8c3d7; line-height: 1.5; }
+
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }


### PR DESCRIPTION
## Summary
- add a heart-rate card that explains camera-based estimation and live BPM
- sample green-channel data over time, estimate BPM spectrally, and speak stateful phrases based on heart rate
- tie heart-rate sampling into existing metric timers with proper reset and cooldown behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69300b9370e08329b41f2e5f506a49ed)